### PR TITLE
P34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 resolver = "2"
 members = [
-    "p12", "p22", "p24",
+    "p12", "p22", "p24", "p34",
 ]

--- a/p34/Cargo.toml
+++ b/p34/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "p34"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/p34/src/lib.rs
+++ b/p34/src/lib.rs
@@ -43,7 +43,7 @@ impl<T: BigNumOps, const N: usize> Add for BigUint<T, N> {
             carry = (overflow1 || overflow2).into();
         }
         if carry > T::default() {
-            panic!("Overflow for when adding values of size {}.", N * 64);
+            panic!("Overflow, addition exceeds type representation.");
         }
         out
     }

--- a/p34/src/lib.rs
+++ b/p34/src/lib.rs
@@ -1,0 +1,120 @@
+use std::ops::Add;
+
+trait BigNumOps: Sized + Default + Copy + PartialOrd + From<bool> {
+    fn add_overflow(self, rhs: Self) -> (Self, bool);
+}
+
+impl BigNumOps for u64 {
+    fn add_overflow(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+}
+
+impl BigNumOps for u32 {
+    fn add_overflow(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct BigUint<T: BigNumOps, const N: usize> {
+    limbs: [T; N],
+}
+
+impl<T, const N: usize> Default for BigUint<T, N>
+where
+    T: BigNumOps + Default + Copy,
+{
+    fn default() -> Self {
+        BigUint {
+            limbs: [T::default(); N],
+        }
+    }
+}
+
+impl<T, const N: usize> Add for BigUint<T, N>
+where
+    T: BigNumOps + Default + Copy,
+{
+    type Output = BigUint<T, N>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut out = BigUint::default();
+        let mut carry: T = T::default();
+
+        for i in 0..N {
+            let (sum, overflow1) = self.limbs[i].add_overflow(rhs.limbs[i]);
+            let (sum, overflow2) = sum.add_overflow(carry);
+            out.limbs[i] = sum;
+            carry = (overflow1 || overflow2).into();
+        }
+        if carry > T::default() {
+            panic!("Overflow for when adding values of size {}.", N * 64);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type BU64 = BigUint<u64, 2>;
+    type BU32 = BigUint<u32, 2>;
+
+    #[test]
+    fn test_bu64_add() {
+        let u1 = BU64 { limbs: [0x1, 0x1] };
+        let u2 = BU64 { limbs: [0x1, 0x0] };
+        let u3 = BU64 { limbs: [0x2, 0x1] };
+        assert_eq!(u1 + u2, u3);
+    }
+
+    #[test]
+    fn test_bu64_add_overflow() {
+        let u1 = BU64 {
+            limbs: [0xFFFFFFFFFFFFFFFF, 0x0],
+        };
+        let u2 = BU64 { limbs: [0x1, 0x0] };
+        let u3 = BU64 { limbs: [0x0, 0x1] };
+        assert_eq!(u1 + u2, u3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bu64_add_overflow_panix() {
+        let u1 = BU64 {
+            limbs: [0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF],
+        };
+        let u2 = BU64 { limbs: [0x1, 0x0] };
+        let _ = u1 + u2;
+    }
+
+    #[test]
+    fn test_bu32_add() {
+        let u1 = BU32 { limbs: [0x1, 0x1] };
+        let u2 = BU32 { limbs: [0x1, 0x0] };
+        let u3 = BU32 { limbs: [0x2, 0x1] };
+        assert_eq!(u1 + u2, u3);
+    }
+
+    #[test]
+    fn test_bu32_add_overflow() {
+        let u1 = BU32 {
+            limbs: [0xFFFFFFFF, 0x0],
+        };
+        let u2 = BU32 { limbs: [0x1, 0x0] };
+        let u3 = BU32 { limbs: [0x0, 0x1] };
+        assert_eq!(u1 + u2, u3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bu32_add_overflow_panix() {
+        let u1 = BU32 {
+            limbs: [0xFFFFFFFF, 0xFFFFFFFF],
+        };
+        let u2 = BU32 { limbs: [0x1, 0x0] };
+        let _ = u1 + u2;
+    }
+}

--- a/p34/src/lib.rs
+++ b/p34/src/lib.rs
@@ -1,6 +1,7 @@
+use std::fmt::Debug;
 use std::ops::Add;
 
-trait BigNumOps: Sized + Default + Copy + PartialOrd + From<bool> {
+trait BigNumOps: Debug + Sized + Default + Copy + PartialOrd + From<bool> {
     fn add_overflow(self, rhs: Self) -> (Self, bool);
 }
 
@@ -42,9 +43,7 @@ impl<T: BigNumOps, const N: usize> Add for BigUint<T, N> {
             out.limbs[i] = sum;
             carry = (overflow1 || overflow2).into();
         }
-        if carry > T::default() {
-            panic!("Overflow, addition exceeds type representation.");
-        }
+        debug_assert_eq!(carry, T::default());
         out
     }
 }
@@ -75,8 +74,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
-    fn test_bu64_add_overflow_panix() {
+    fn test_bu64_add_overflow_panics() {
         let u1 = BU64 {
             limbs: [0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF],
         };
@@ -103,8 +103,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
-    fn test_bu32_add_overflow_panix() {
+    fn test_bu32_add_overflow_panics() {
         let u1 = BU32 {
             limbs: [0xFFFFFFFF, 0xFFFFFFFF],
         };

--- a/p34/src/lib.rs
+++ b/p34/src/lib.rs
@@ -21,10 +21,7 @@ struct BigUint<T: BigNumOps, const N: usize> {
     limbs: [T; N],
 }
 
-impl<T, const N: usize> Default for BigUint<T, N>
-where
-    T: BigNumOps + Default + Copy,
-{
+impl<T: BigNumOps, const N: usize> Default for BigUint<T, N> {
     fn default() -> Self {
         BigUint {
             limbs: [T::default(); N],
@@ -32,10 +29,7 @@ where
     }
 }
 
-impl<T, const N: usize> Add for BigUint<T, N>
-where
-    T: BigNumOps + Default + Copy,
-{
+impl<T: BigNumOps, const N: usize> Add for BigUint<T, N> {
     type Output = BigUint<T, N>;
 
     fn add(self, rhs: Self) -> Self::Output {


### PR DESCRIPTION
I did a bit of an extra work to allow other primitive types defined by user, such as u32. 
I was wondering if there is an advantage to doing this way or is it better to do it the idiomatic way with macros that creates the BigUint type for all primitive types? How unsafe is my code? why?